### PR TITLE
Underprint document with white background

### DIFF
--- a/libpretixprint/src/main/java/eu/pretix/libpretixprint/templating/Layout.java
+++ b/libpretixprint/src/main/java/eu/pretix/libpretixprint/templating/Layout.java
@@ -13,6 +13,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.awt.Color;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -225,6 +226,13 @@ public class Layout {
         cb.restoreState();
     }
 
+    private void drawWhiteBackground(Rectangle pageSize, PdfContentByte cb) throws DocumentException {
+        Rectangle r = new Rectangle(pageSize);
+        r.setBackgroundColor(Color.WHITE);
+        r.setBorder(Rectangle.NO_BORDER);
+        cb.rectangle(r);
+    }
+
     public void render(String filename)
             throws Exception {
         render(new FileOutputStream(filename));
@@ -266,6 +274,9 @@ public class Layout {
 
                 if (reader != null) {
                     document.setPageSize(reader.getPageSize(pagenum + 1));
+                }
+                drawWhiteBackground(document.getPageSize(), cb);
+                if (reader != null) {
                     cb.addTemplate(writer.getImportedPage(reader, pagenum + 1), 0, 0);
                 }
 


### PR DESCRIPTION
Adds a full page size white rectangle as first element on the page.
This fixes issues with printers that don't understand transparency. 
See the Evolis card printer example in https://github.com/pretix/pretixprint-android/pull/23 and our addition for LinkOS printers in https://github.com/pretix/pretixprint-android/pull/17